### PR TITLE
Fix/memory leak

### DIFF
--- a/Test/Screens/Reviews/ReviewsViewModel.swift
+++ b/Test/Screens/Reviews/ReviewsViewModel.swift
@@ -89,7 +89,9 @@ private extension ReviewsViewModel {
             created: created,
             userName: fullName,
             ratingImage: ratingImage,
-            onTapShowMore: showMoreReview
+            onTapShowMore: { [weak self] id in
+                self?.showMoreReview(with: id)
+            }
         )
         return item
     }


### PR DESCRIPTION
# Требования
Найти утечки памяти и исправить их

# Бэкграунд
Утечка памяти происходила из-за `reference`-цикла между `ReviewsViewModel` и `ReviewCellConfig` при передаче метода `showMoreReview(with:)` с сильными захватом `self`

# Описание решения
Поправил утечку добавив слабый захват `self` вью-модели, чтобы на нее не было лишних сильных ссылок