### PR TITLE
Fix/make scrolling smooth

### DIFF
--- a/Test/Screens/Reviews/ReviewsViewModel.swift
+++ b/Test/Screens/Reviews/ReviewsViewModel.swift
@@ -36,7 +36,11 @@ extension ReviewsViewModel {
     func getReviews() {
         guard state.shouldLoad else { return }
         state.shouldLoad = false
-        reviewsProvider.getReviews(offset: state.offset, completion: gotReviews)
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+            guard let self else { return }
+
+            reviewsProvider.getReviews(offset: state.offset, completion: gotReviews)
+        }
     }
 
 }
@@ -56,7 +60,12 @@ private extension ReviewsViewModel {
         } catch {
             state.shouldLoad = true
         }
-        onStateChange?(state)
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            
+            onStateChange?(state)
+        }
     }
 
     /// Метод, вызываемый при нажатии на кнопку "Показать полностью...".


### PR DESCRIPTION
# Требования
Найти проблему с UI-перформансом (плавностью скроллинга) и исправить её

# Бэкграунд
Проблема возникала из-за того, что код симуляции сетевого запроса `usleep(.random(in: 100_000...1_000_000))` вызывался на главной очереди, что блокировало обновление интерфейса. в данном случае лагал скролл, так как загрузка новых отзывов происходит по мере того, как пользователь скролит таблицу вниз

# Описание решения
Вынес запрос отзывов на глобальную очередь с приоритетом `userInteractive` (так как пользователь скролит таблицу прямо сейчас и ответ нужно получить максимально быстро), а вызов замыкания `onStateChange` осуществляю с главной очереди, на которой должен обновляться UI