### PR TITLE
Feat/add pull to refresh

### DIFF
--- a/Test/Screens/Reviews/ReviewsView.swift
+++ b/Test/Screens/Reviews/ReviewsView.swift
@@ -3,7 +3,9 @@ import UIKit
 final class ReviewsView: UIView {
 
     let tableView = UITableView()
+    let refreshControl = UIRefreshControl()
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -34,6 +36,7 @@ private extension ReviewsView {
         tableView.separatorStyle = .none
         tableView.allowsSelection = false
         tableView.register(ReviewCell.self, forCellReuseIdentifier: ReviewCellConfig.reuseId)
+        tableView.refreshControl = refreshControl
     }
 
 }

--- a/Test/Screens/Reviews/ReviewsViewController.swift
+++ b/Test/Screens/Reviews/ReviewsViewController.swift
@@ -10,6 +10,7 @@ final class ReviewsViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -35,13 +36,24 @@ private extension ReviewsViewController {
         let reviewsView = ReviewsView()
         reviewsView.tableView.delegate = viewModel
         reviewsView.tableView.dataSource = viewModel
+        reviewsView.refreshControl.addTarget(
+            self,
+            action: #selector(didPullToRefreshReviews),
+            for: .valueChanged
+        )
         return reviewsView
     }
 
     func setupViewModel() {
         viewModel.onStateChange = { [weak reviewsView] _ in
+            reviewsView?.refreshControl.endRefreshing()
             reviewsView?.tableView.reloadData()
         }
+    }
+
+    @objc
+    func didPullToRefreshReviews() {
+        viewModel.refreshReviews()
     }
 
 }

--- a/Test/Screens/Reviews/ReviewsViewModel.swift
+++ b/Test/Screens/Reviews/ReviewsViewModel.swift
@@ -43,6 +43,14 @@ extension ReviewsViewModel {
         }
     }
 
+    /// Метод повторной загрузки отзывов
+    func refreshReviews() {
+        state.offset = 0
+        state.shouldLoad = true
+
+        getReviews()
+    }
+
 }
 
 // MARK: - Private
@@ -54,7 +62,12 @@ private extension ReviewsViewModel {
         do {
             let data = try result.get()
             let reviews = try decoder.decode(Reviews.self, from: data)
-            state.items += reviews.items.map(makeReviewItem)
+            let items = reviews.items.map(makeReviewItem)
+            if state.offset == .zero {
+                state.items = items
+            } else {
+                state.items += items
+            }
             state.offset += state.limit
             state.shouldLoad = state.offset < reviews.count
         } catch {


### PR DESCRIPTION
# Требования
Реализовать pull-to-refresh для повторной загрузки отзывов

# Описание решения
- добавил `UIRefreshControl` на `UITableView`
- добавил метод, который вызывается при действии pull-to-refresh
- добавил логику сброса текущего оффсета и необходимости загрузки (если вдруг пользователь "загрузил" все отзывы, и `state.shouldLoad == false`)
- в методе `gotReviews(_:)` добавил проверку на текущий оффсет, в соответствии с которой загруженные отзывы либо добавляются к существующим, либо перезаписывают массив отзывов
- немного порефакторил код: `@available(*, unavailable)` к инициализатору `required init?(coder: NSCoder)`