### PR TITLE
Feat/reviews total count cell

### DIFF
--- a/Test.xcodeproj/project.pbxproj
+++ b/Test.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		21ED1F602D69C85E0012D6F6 /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ED1F5F2D69C85E0012D6F6 /* RootViewController.swift */; };
 		21ED1F622D69CBCD0012D6F6 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ED1F612D69CBCD0012D6F6 /* RootView.swift */; };
 		21ED1F652D69D0340012D6F6 /* ReviewsScreenFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ED1F642D69D0340012D6F6 /* ReviewsScreenFactory.swift */; };
+		52E851A12E11F530000D330F /* ReviewsTotalCountCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E851A02E11F51F000D330F /* ReviewsTotalCountCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +52,7 @@
 		21ED1F5F2D69C85E0012D6F6 /* RootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewController.swift; sourceTree = "<group>"; };
 		21ED1F612D69CBCD0012D6F6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		21ED1F642D69D0340012D6F6 /* ReviewsScreenFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsScreenFactory.swift; sourceTree = "<group>"; };
+		52E851A02E11F51F000D330F /* ReviewsTotalCountCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsTotalCountCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +87,7 @@
 			isa = PBXGroup;
 			children = (
 				21B82E252D47B0640085DAA2 /* ReviewCell.swift */,
+				52E851A02E11F51F000D330F /* ReviewsTotalCountCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -270,6 +273,7 @@
 				21ED1F602D69C85E0012D6F6 /* RootViewController.swift in Sources */,
 				21B82E342D47B0AA0085DAA2 /* ReviewsViewModel.swift in Sources */,
 				21B8416B2D47BFA10085DAA2 /* Reviews.swift in Sources */,
+				52E851A12E11F530000D330F /* ReviewsTotalCountCell.swift in Sources */,
 				21B82E302D47B0640085DAA2 /* ReviewsViewController.swift in Sources */,
 				2166A0F42D4A5B25009AAA76 /* ReviewsView.swift in Sources */,
 				216668732D48E89A009AAA76 /* Colors.swift in Sources */,

--- a/Test/Model/Reviews.swift
+++ b/Test/Model/Reviews.swift
@@ -4,6 +4,6 @@ struct Reviews: Decodable {
     /// Модели отзывов.
     let items: [Review]
     /// Общее количество отзывов.
-    let count: Int
+    let count: UInt
 
 }

--- a/Test/Screens/Reviews/Cells/ReviewsTotalCountCell.swift
+++ b/Test/Screens/Reviews/Cells/ReviewsTotalCountCell.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+typealias ReviewsTotalCountCell = UITableViewCell
+
+struct ReviewsTotalCountCellConfig {
+
+    /// Идентификатор для переиспользования ячейки
+    static let reuseId = String(describing: ReviewsTotalCountCellConfig.self)
+
+    /// Текст про количество отзывов всего
+    let text: String
+
+}
+
+// MARK: - TableCellConfig
+
+extension ReviewsTotalCountCellConfig: TableCellConfig {
+
+    func update(cell: UITableViewCell) {
+        var contentConfiguration = cell.defaultContentConfiguration()
+        contentConfiguration.text = text
+        contentConfiguration.textProperties.alignment = .center
+        contentConfiguration.textProperties.font = .reviewCount
+        contentConfiguration.textProperties.color = .reviewCount
+        cell.contentConfiguration = contentConfiguration
+    }
+
+    func height(with size: CGSize) -> CGFloat {
+        UITableView.automaticDimension
+    }
+
+}

--- a/Test/Screens/Reviews/ReviewsView.swift
+++ b/Test/Screens/Reviews/ReviewsView.swift
@@ -36,6 +36,7 @@ private extension ReviewsView {
         tableView.separatorStyle = .none
         tableView.allowsSelection = false
         tableView.register(ReviewCell.self, forCellReuseIdentifier: ReviewCellConfig.reuseId)
+        tableView.register(ReviewsTotalCountCell.self, forCellReuseIdentifier: ReviewsTotalCountCellConfig.reuseId)
         tableView.refreshControl = refreshControl
     }
 

--- a/Test/Screens/Reviews/ReviewsViewModel.swift
+++ b/Test/Screens/Reviews/ReviewsViewModel.swift
@@ -70,6 +70,10 @@ private extension ReviewsViewModel {
             }
             state.offset += state.limit
             state.shouldLoad = state.offset < reviews.count
+
+            if !state.shouldLoad {
+                state.items.append(makeReviewsTotalCountItem(reviewsCount: reviews.count))
+            }
         } catch {
             state.shouldLoad = true
         }
@@ -116,6 +120,12 @@ private extension ReviewsViewModel {
             }
         )
         return item
+    }
+
+    typealias ReviewsTotalCountItem = ReviewsTotalCountCellConfig
+
+    func makeReviewsTotalCountItem(reviewsCount: UInt) -> ReviewsTotalCountItem {
+        ReviewsTotalCountItem(text: "\(reviewsCount) отзывов")
     }
 
 }


### PR DESCRIPTION
# Требования
Добавить новую ячейку, которая будет последней в списке отзывов, в которой будет один текст посередине, отображающий общее количество отзывов 

# Описание решения
- добавил ячейку для количества отзывов (`typealias` на `UITableViewCell`, потому что базовой ячейки достаточно), и конфигурацию для нее
- изменил тип свойства `count` у структуры `Reviews` на `UInt`, так как количество отзывов не может быть отрицательным
- зарегистрировал ячейку и реализовал логику добавления конфига ячейки, когда загрузились все отзывы

# Скриншот
<img width="300" src="https://github.com/user-attachments/assets/9ce367da-b74e-4ab4-91a6-e08d5dbcb5af">