### PR TITLE
Feat/async image loading

### DIFF
--- a/Test.xcodeproj/project.pbxproj
+++ b/Test.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		21ED1F622D69CBCD0012D6F6 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ED1F612D69CBCD0012D6F6 /* RootView.swift */; };
 		21ED1F652D69D0340012D6F6 /* ReviewsScreenFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ED1F642D69D0340012D6F6 /* ReviewsScreenFactory.swift */; };
 		52E851A12E11F530000D330F /* ReviewsTotalCountCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E851A02E11F51F000D330F /* ReviewsTotalCountCell.swift */; };
+		52E851A62E1201BB000D330F /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E851A52E1201BB000D330F /* ImageLoader.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -53,6 +54,7 @@
 		21ED1F612D69CBCD0012D6F6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		21ED1F642D69D0340012D6F6 /* ReviewsScreenFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsScreenFactory.swift; sourceTree = "<group>"; };
 		52E851A02E11F51F000D330F /* ReviewsTotalCountCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsTotalCountCell.swift; sourceTree = "<group>"; };
+		52E851A52E1201BB000D330F /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +140,7 @@
 		21B82E2C2D47B0640085DAA2 /* Test */ = {
 			isa = PBXGroup;
 			children = (
+				52E851A42E1201AB000D330F /* ImageLoader */,
 				21B82E2B2D47B0640085DAA2 /* AppDelegate.swift */,
 				21B82E2A2D47B0640085DAA2 /* Screens */,
 				2166686D2D48DEBF009AAA76 /* Protocols */,
@@ -188,6 +191,14 @@
 				21ED1F612D69CBCD0012D6F6 /* RootView.swift */,
 			);
 			path = Root;
+			sourceTree = "<group>";
+		};
+		52E851A42E1201AB000D330F /* ImageLoader */ = {
+			isa = PBXGroup;
+			children = (
+				52E851A52E1201BB000D330F /* ImageLoader.swift */,
+			);
+			path = ImageLoader;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -265,6 +276,7 @@
 			files = (
 				21B82E392D47B1320085DAA2 /* Review.swift in Sources */,
 				21B8416D2D47C0E20085DAA2 /* ReviewsViewModelState.swift in Sources */,
+				52E851A62E1201BB000D330F /* ImageLoader.swift in Sources */,
 				21B82E2E2D47B0640085DAA2 /* ReviewCell.swift in Sources */,
 				21ED1F622D69CBCD0012D6F6 /* RootView.swift in Sources */,
 				21667B802D4A25B2009AAA76 /* RatingRenderer.swift in Sources */,

--- a/Test/ImageLoader/ImageLoader.swift
+++ b/Test/ImageLoader/ImageLoader.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+final class ImageLoader {
+
+    private let memoryCache = NSCache<NSURL, UIImage>()
+
+    static let shared = ImageLoader()
+
+    private init() {
+        memoryCache.totalCostLimit = 50 * 1024 * 1024 // ~50 MB
+    }
+
+    func image(for url: URL) async -> UIImage? {
+        if let cachedImage = memoryCache.object(forKey: url as NSURL) {
+            return cachedImage
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+
+            if let image = UIImage(data: data) {
+                memoryCache.setObject(
+                    image,
+                    forKey: url as NSURL,
+                    cost: imageCost(image: image)
+                )
+
+                return image
+            }
+        } catch {
+            print("При загрузке изображения произошла ошибка: \(error)")
+        }
+
+        return nil
+    }
+
+    private func imageCost(image: UIImage) -> Int {
+        guard let cgImage = image.cgImage else { return 1 }
+
+        return cgImage.bytesPerRow * cgImage.height
+    }
+
+}

--- a/Test/Model/Review.swift
+++ b/Test/Model/Review.swift
@@ -1,9 +1,13 @@
+import Foundation
+
 /// Модель отзыва.
 struct Review: Decodable {
     /// Имя пользователя
     let firstName: String
     /// Фамилия пользователя
     let lastName: String
+    /// Ссылка на аватар пользователя
+    let avatarUrl: URL?
     /// Текст отзыва
     let text: String
     /// Время создания отзыва

--- a/Test/Resources/Responses/getReviews.response.json
+++ b/Test/Resources/Responses/getReviews.response.json
@@ -4,6 +4,7 @@
         {
             "first_name": "Иван",
             "last_name": "Петров",
+            "avatar_url": "https://sun9-8.userapi.com/s/v1/ig2/aIEjedUmOO40f6ioEsDMuOOv3y5EQi6Uc1fXutMBgSt5mG-HenbmridQrGsOd0BP9s7HMSSIcbWO7V7rBN5cMRWP.jpg?quality=95&as=32x32,48x48,72x72,108x108,160x160,240x240,360x360,480x480,540x540,640x640,720x720,1080x1080&from=bu&cs=1080x0",
             "rating": 5,
             "text": "Кроссовки хорошие. Удобные. Как по мне сшиты.",
             "created": "1 час назад"
@@ -11,6 +12,7 @@
         {
             "first_name": "Екатерина",
             "last_name": "Иванова",
+            "avatar_url": "https://sun151-1.userapi.com/s/v1/ig2/qQm4sBLWEzx_xcByDtUEyQDYuq0boytD9MiWo9UcWcoNmz0X0_3QhPuzPeAj6Gy2IV3kX5lLzJrOVqPwMzVcR3YY.jpg?quality=95&as=32x35,48x53,72x79,108x119,160x176,240x264,360x396,480x528,540x594,640x705,720x793,1080x1189,1170x1288&from=bu&cs=1170x0",
             "rating": 3,
             "text": "Скользские ужасно.",
             "created": "12 минут назад"
@@ -18,6 +20,7 @@
         {
             "first_name": "Евгения",
             "last_name": "Петрова",
+            "avatar_url": "https://sun9-7.userapi.com/s/v1/if2/E6Ar_mnRI2w3WuK4qgRUlkqJ53bYoMRM8VTUe6ekbKCYu3mzPegpPasl7iqzpMLfDWumhXOeIQeKQpWk5DSfZOPf.jpg?quality=95&as=32x23,48x34,72x51,108x76,160x113,240x169,360x254,480x339,540x381,640x451,720x508,1080x762,1280x903&from=bu&cs=1280x0",
             "rating": 4,
             "text": "Прошла по снегу 30 метров, 5 раз упала. Спасибо мужу, поддерживал. Возврат, к сожалению.",
             "created": "35 минут назад"
@@ -32,6 +35,7 @@
         {
             "first_name": "Никита",
             "last_name": "Иванов",
+            "avatar_url": "https://sun9-24.userapi.com/s/v1/ig2/s9Mw-hQsApaSHqWMpB4WMwoQZy6Xx-DjEag0Tj3nFbo8T6r-KSIlT2VnOStTjjf3tbMDzis0vqW8DuRd0GSYWfBD.jpg?quality=95&as=32x37,48x56,72x84,108x126,160x187,240x281,360x421,480x561,540x632,640x749,684x800&from=bu&cs=684x0",
             "rating": 5,
             "text": "Отлично выглядят, хоть и скользковатые...",
             "created": "только что"
@@ -39,6 +43,7 @@
         {
             "first_name": "Олег",
             "last_name": "Николаев",
+            "avatar_url": "https://sun9-9.userapi.com/s/v1/ig2/-Y8ynz5hm0-YWyDw9dQYCu3ve3B-G-jj3ecERStiW9b01rLw3G9EoJym_ocQDoqHGQKXuku8PfboxSWbbCBe05Da.jpg?quality=95&as=32x40,48x61,72x91,108x136,160x202,240x303,360x454,480x606,540x681,640x807,720x908,856x1080&from=bu&cs=856x0",
             "rating": 1,
             "text": "Ребёнок жалуется, что очень скользские. Пока шла до школы...",
             "created": "15 минут назад"
@@ -55,6 +60,7 @@
         {
             "first_name": "Иван",
             "last_name": "Петров",
+            "avatar_url": "https://sun9-8.userapi.com/s/v1/ig2/aIEjedUmOO40f6ioEsDMuOOv3y5EQi6Uc1fXutMBgSt5mG-HenbmridQrGsOd0BP9s7HMSSIcbWO7V7rBN5cMRWP.jpg?quality=95&as=32x32,48x48,72x72,108x108,160x160,240x240,360x360,480x480,540x540,640x640,720x720,1080x1080&from=bu&cs=1080x0",
             "rating": 5,
             "text": "Кроссовки хорошие. Удобные. Как по мне сшиты.",
             "created": "1 час назад"
@@ -62,6 +68,7 @@
         {
             "first_name": "Екатерина",
             "last_name": "Иванова",
+            "avatar_url": "https://sun151-1.userapi.com/s/v1/ig2/qQm4sBLWEzx_xcByDtUEyQDYuq0boytD9MiWo9UcWcoNmz0X0_3QhPuzPeAj6Gy2IV3kX5lLzJrOVqPwMzVcR3YY.jpg?quality=95&as=32x35,48x53,72x79,108x119,160x176,240x264,360x396,480x528,540x594,640x705,720x793,1080x1189,1170x1288&from=bu&cs=1170x0",
             "rating": 3,
             "text": "Скользские ужасно.",
             "created": "12 минут назад"
@@ -69,6 +76,7 @@
         {
             "first_name": "Евгения",
             "last_name": "Петрова",
+            "avatar_url": "https://sun9-7.userapi.com/s/v1/if2/E6Ar_mnRI2w3WuK4qgRUlkqJ53bYoMRM8VTUe6ekbKCYu3mzPegpPasl7iqzpMLfDWumhXOeIQeKQpWk5DSfZOPf.jpg?quality=95&as=32x23,48x34,72x51,108x76,160x113,240x169,360x254,480x339,540x381,640x451,720x508,1080x762,1280x903&from=bu&cs=1280x0",
             "rating": 4,
             "text": "Прошла по снегу 30 метров, 5 раз упала. Спасибо мужу, поддерживал. Возврат, к сожалению.",
             "created": "35 минут назад"
@@ -83,6 +91,7 @@
         {
             "first_name": "Никита",
             "last_name": "Иванов",
+            "avatar_url": "https://sun9-24.userapi.com/s/v1/ig2/s9Mw-hQsApaSHqWMpB4WMwoQZy6Xx-DjEag0Tj3nFbo8T6r-KSIlT2VnOStTjjf3tbMDzis0vqW8DuRd0GSYWfBD.jpg?quality=95&as=32x37,48x56,72x84,108x126,160x187,240x281,360x421,480x561,540x632,640x749,684x800&from=bu&cs=684x0",
             "rating": 5,
             "text": "Отлично выглядят, хоть и скользковатые...",
             "created": "только что"
@@ -90,6 +99,7 @@
         {
             "first_name": "Олег",
             "last_name": "Николаев",
+            "avatar_url": "https://sun9-9.userapi.com/s/v1/ig2/-Y8ynz5hm0-YWyDw9dQYCu3ve3B-G-jj3ecERStiW9b01rLw3G9EoJym_ocQDoqHGQKXuku8PfboxSWbbCBe05Da.jpg?quality=95&as=32x40,48x61,72x91,108x136,160x202,240x303,360x454,480x606,540x681,640x807,720x908,856x1080&from=bu&cs=856x0",
             "rating": 1,
             "text": "Ребёнок жалуется, что очень скользские. Пока шла до школы...",
             "created": "15 минут назад"
@@ -106,6 +116,7 @@
         {
             "first_name": "Иван",
             "last_name": "Петров",
+            "avatar_url": "https://sun9-8.userapi.com/s/v1/ig2/aIEjedUmOO40f6ioEsDMuOOv3y5EQi6Uc1fXutMBgSt5mG-HenbmridQrGsOd0BP9s7HMSSIcbWO7V7rBN5cMRWP.jpg?quality=95&as=32x32,48x48,72x72,108x108,160x160,240x240,360x360,480x480,540x540,640x640,720x720,1080x1080&from=bu&cs=1080x0",
             "rating": 5,
             "text": "Кроссовки хорошие. Удобные. Как по мне сшиты.",
             "created": "1 час назад"
@@ -113,6 +124,7 @@
         {
             "first_name": "Екатерина",
             "last_name": "Иванова",
+            "avatar_url": "https://sun151-1.userapi.com/s/v1/ig2/qQm4sBLWEzx_xcByDtUEyQDYuq0boytD9MiWo9UcWcoNmz0X0_3QhPuzPeAj6Gy2IV3kX5lLzJrOVqPwMzVcR3YY.jpg?quality=95&as=32x35,48x53,72x79,108x119,160x176,240x264,360x396,480x528,540x594,640x705,720x793,1080x1189,1170x1288&from=bu&cs=1170x0",
             "rating": 3,
             "text": "Скользские ужасно.",
             "created": "12 минут назад"
@@ -134,6 +146,7 @@
         {
             "first_name": "Никита",
             "last_name": "Иванов",
+            "avatar_url": "https://sun9-24.userapi.com/s/v1/ig2/s9Mw-hQsApaSHqWMpB4WMwoQZy6Xx-DjEag0Tj3nFbo8T6r-KSIlT2VnOStTjjf3tbMDzis0vqW8DuRd0GSYWfBD.jpg?quality=95&as=32x37,48x56,72x84,108x126,160x187,240x281,360x421,480x561,540x632,640x749,684x800&from=bu&cs=684x0",
             "rating": 5,
             "text": "Отлично выглядят, хоть и скользковатые...",
             "created": "только что"
@@ -141,6 +154,7 @@
         {
             "first_name": "Олег",
             "last_name": "Николаев",
+            "avatar_url": "https://sun9-9.userapi.com/s/v1/ig2/-Y8ynz5hm0-YWyDw9dQYCu3ve3B-G-jj3ecERStiW9b01rLw3G9EoJym_ocQDoqHGQKXuku8PfboxSWbbCBe05Da.jpg?quality=95&as=32x40,48x61,72x91,108x136,160x202,240x303,360x454,480x606,540x681,640x807,720x908,856x1080&from=bu&cs=856x0",
             "rating": 1,
             "text": "Ребёнок жалуется, что очень скользские. Пока шла до школы...",
             "created": "15 минут назад"


### PR DESCRIPTION
# Требования
Добавить в json файл в объект отзыва поле `avatar_url` с валидной ссылкой на изображение и сделать асинхронную загрузку этого изображения. Ссылок должно быть не менее двух разных (при этом можно скопировать в разные отзывы одни и те же ссылки). Будет хорошо, если также будет предусмотрено кэширование изображений.

# Описание решения
- добавил загрузчик изображений с кэшированием в `NSCache` с лимитом 50 мб. кэширование аватарок пользователей на диске кажется избыточным, так как увеличивает размер установленного приложения и подразумевает дополнительный функционал очистки этого кэша
- в json с отзывами добавил соответствующее поле со ссылкой на изображение для аватара пользователя
- добавил загрузку изобаржения аватара пользователя в методе `update(cell:)` у `ReviewCellConfig` с отменой загрузки при переиспользовании ячейки. для операций загрузки использовал `async/await` и `Task`