### PR TITLE
fix: pass missing avatarUrl to ReviewCellConfig

### DIFF
--- a/Test/Screens/Reviews/ReviewsViewModel.swift
+++ b/Test/Screens/Reviews/ReviewsViewModel.swift
@@ -115,6 +115,7 @@ private extension ReviewsViewModel {
             created: created,
             userName: fullName,
             ratingImage: ratingImage,
+            avatarUrl: review.avatarUrl,
             onTapShowMore: { [weak self] id in
                 self?.showMoreReview(with: id)
             }


### PR DESCRIPTION
Забыл прокинуть `avatarUrl` в `ReviewCellConfig`