### PR TITLE
Feat/loading indicator

### DIFF
--- a/Test/Screens/Reviews/ReviewsView.swift
+++ b/Test/Screens/Reviews/ReviewsView.swift
@@ -5,6 +5,8 @@ final class ReviewsView: UIView {
     let tableView = UITableView()
     let refreshControl = UIRefreshControl()
 
+    private let loadingView = LoadingView()
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -18,6 +20,11 @@ final class ReviewsView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         tableView.frame = bounds.inset(by: safeAreaInsets)
+        loadingView.frame = tableView.frame
+    }
+
+    func setLoadingViewHidden(_ isHidden: Bool) {
+        loadingView.isHidden = isHidden
     }
 
 }
@@ -29,6 +36,7 @@ private extension ReviewsView {
     func setupView() {
         backgroundColor = .systemBackground
         setupTableView()
+        setupLoadingView()
     }
 
     func setupTableView() {
@@ -38,6 +46,45 @@ private extension ReviewsView {
         tableView.register(ReviewCell.self, forCellReuseIdentifier: ReviewCellConfig.reuseId)
         tableView.register(ReviewsTotalCountCell.self, forCellReuseIdentifier: ReviewsTotalCountCellConfig.reuseId)
         tableView.refreshControl = refreshControl
+    }
+
+    func setupLoadingView() {
+        addSubview(loadingView)
+        loadingView.isHidden = true
+    }
+
+}
+
+// MARK: - LoadingView
+
+private extension ReviewsView {
+
+    final class LoadingView: UIView {
+
+        private let activityIndicator = UIActivityIndicatorView(style: .large)
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+
+            backgroundColor = .systemBackground
+
+            addSubview(activityIndicator)
+
+            activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+
+            NSLayoutConstraint.activate([
+                activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+                activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor)
+            ])
+
+            activityIndicator.startAnimating()
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
     }
 
 }

--- a/Test/Screens/Reviews/ReviewsViewModelState.swift
+++ b/Test/Screens/Reviews/ReviewsViewModelState.swift
@@ -7,3 +7,9 @@ struct ReviewsViewModelState {
     var shouldLoad = true
 
 }
+
+enum ReviewsViewState {
+    case loading
+    case content
+    case error
+}


### PR DESCRIPTION
# Требования
Добавить индикатор загрузки при первой загрузке отзывов

# Описание решения
- добавил `LoadingView`, которая отображается поверх таблицы в `ReviewsView` в нужный момент
- добавил `enum ReviewsViewState` для состояний загрузки, отображения контента и ошибки (не обрабатывал)
- модифицировал замыкание `onStateChange`, теперь оно принимает `ReviewsViewState`, а в контроллере происходит обработка этих состояний (передаваемый ранее стейт нигде не обрабатывался, поэтому на данный момент он не передается)