### PR TITLE
Feat/review photos

### DIFF
--- a/Test/Model/Review.swift
+++ b/Test/Model/Review.swift
@@ -8,6 +8,8 @@ struct Review: Decodable {
     let lastName: String
     /// Ссылка на аватар пользователя
     let avatarUrl: URL?
+    /// Названия фотографий
+    var photos: [String]?
     /// Текст отзыва
     let text: String
     /// Время создания отзыва

--- a/Test/Resources/Responses/getReviews.response.json
+++ b/Test/Resources/Responses/getReviews.response.json
@@ -5,6 +5,7 @@
             "first_name": "Иван",
             "last_name": "Петров",
             "avatar_url": "https://sun9-8.userapi.com/s/v1/ig2/aIEjedUmOO40f6ioEsDMuOOv3y5EQi6Uc1fXutMBgSt5mG-HenbmridQrGsOd0BP9s7HMSSIcbWO7V7rBN5cMRWP.jpg?quality=95&as=32x32,48x48,72x72,108x108,160x160,240x240,360x360,480x480,540x540,640x640,720x720,1080x1080&from=bu&cs=1080x0",
+            "photos": ["IMG_0001", "IMG_0002", "IMG_0003", "IMG_0004", "IMG_0005", "IMG_0006", "IMG_0001"],
             "rating": 5,
             "text": "Кроссовки хорошие. Удобные. Как по мне сшиты.",
             "created": "1 час назад"
@@ -28,6 +29,7 @@
         {
             "first_name": "Илья",
             "last_name": "Петров",
+            "photos": ["IMG_0003", "IMG_0004"],
             "rating": 2,
             "text": "Понравилось отношение - несмотря на то, что заказ был выполнен не идеально, продавец был очень любезен и шёл... Прошла по снегу 30 метров, 5 раз упала. Спасибо мужу, поддерживал. Возврат, к сожалению.",
             "created": "минуту назад"
@@ -44,6 +46,7 @@
             "first_name": "Олег",
             "last_name": "Николаев",
             "avatar_url": "https://sun9-9.userapi.com/s/v1/ig2/-Y8ynz5hm0-YWyDw9dQYCu3ve3B-G-jj3ecERStiW9b01rLw3G9EoJym_ocQDoqHGQKXuku8PfboxSWbbCBe05Da.jpg?quality=95&as=32x40,48x61,72x91,108x136,160x202,240x303,360x454,480x606,540x681,640x807,720x908,856x1080&from=bu&cs=856x0",
+            "photos": ["IMG_0005", "IMG_0006"],
             "rating": 1,
             "text": "Ребёнок жалуется, что очень скользские. Пока шла до школы...",
             "created": "15 минут назад"
@@ -84,6 +87,7 @@
         {
             "first_name": "Илья",
             "last_name": "Петров",
+            "photos": ["IMG_0001", "IMG_0002", "IMG_0003", "IMG_0004", "IMG_0005", "IMG_0006", "IMG_0001"],
             "rating": 2,
             "text": "Понравилось отношение - несмотря на то, что заказ был выполнен не идеально, продавец был очень любезен и шёл... Прошла по снегу 30 метров, 5 раз упала. Спасибо мужу, поддерживал. Возврат, к сожалению.",
             "created": "минуту назад"

--- a/Test/Resources/Responses/getReviews.response.json
+++ b/Test/Resources/Responses/getReviews.response.json
@@ -5,7 +5,7 @@
             "first_name": "Иван",
             "last_name": "Петров",
             "avatar_url": "https://sun9-8.userapi.com/s/v1/ig2/aIEjedUmOO40f6ioEsDMuOOv3y5EQi6Uc1fXutMBgSt5mG-HenbmridQrGsOd0BP9s7HMSSIcbWO7V7rBN5cMRWP.jpg?quality=95&as=32x32,48x48,72x72,108x108,160x160,240x240,360x360,480x480,540x540,640x640,720x720,1080x1080&from=bu&cs=1080x0",
-            "photos": ["IMG_0001", "IMG_0002", "IMG_0003", "IMG_0004", "IMG_0005", "IMG_0006", "IMG_0001"],
+            "photos": ["IMG_0001", "IMG_0002", "IMG_0003", "IMG_0004", "IMG_0005"],
             "rating": 5,
             "text": "Кроссовки хорошие. Удобные. Как по мне сшиты.",
             "created": "1 час назад"
@@ -87,7 +87,7 @@
         {
             "first_name": "Илья",
             "last_name": "Петров",
-            "photos": ["IMG_0001", "IMG_0002", "IMG_0003", "IMG_0004", "IMG_0005", "IMG_0006", "IMG_0001"],
+            "photos": ["IMG_0001", "IMG_0002", "IMG_0003", "IMG_0004", "IMG_0005"],
             "rating": 2,
             "text": "Понравилось отношение - несмотря на то, что заказ был выполнен не идеально, продавец был очень любезен и шёл... Прошла по снегу 30 метров, 5 раз упала. Спасибо мужу, поддерживал. Возврат, к сожалению.",
             "created": "минуту назад"

--- a/Test/Screens/Reviews/Cells/ReviewCell.swift
+++ b/Test/Screens/Reviews/Cells/ReviewCell.swift
@@ -92,6 +92,8 @@ final class ReviewCell: UITableViewCell {
     fileprivate let avatarImageView = UIImageView()
     fileprivate let userNameLabel = UILabel()
     fileprivate let ratingImageView = UIImageView()
+    fileprivate let photosStackView = UIStackView()
+    fileprivate let photosScrollView = UIScrollView()
 
     fileprivate var avatarLoadingTask: Task<Void, Never>?
 
@@ -116,6 +118,9 @@ final class ReviewCell: UITableViewCell {
         showMoreButton.frame = layout.showMoreButtonFrame
         userNameLabel.frame = layout.userNameLabelFrame
         ratingImageView.frame = layout.ratingImageFrame
+        photosStackView.frame = layout.photosStackViewFrame
+        photosScrollView.frame = layout.photosScrollViewFrame
+        photosScrollView.contentSize = layout.photosStackViewFrame.size
     }
 
     override func prepareForReuse() {
@@ -145,6 +150,8 @@ private extension ReviewCell {
         setupShowMoreButton()
         setupUserNameLabel()
         setupRatingImageView()
+        setupPhotosScrollView()
+        setupPhotosStackView()
     }
 
     func setupAvatarImageView() {
@@ -185,7 +192,21 @@ private extension ReviewCell {
         contentView.addSubview(ratingImageView)
         ratingImageView.contentMode = .left
     }
-    
+
+    func setupPhotosScrollView() {
+        contentView.addSubview(photosScrollView)
+        photosScrollView.showsHorizontalScrollIndicator = false
+        photosScrollView.showsHorizontalScrollIndicator = false
+    }
+
+    func setupPhotosStackView() {
+        photosScrollView.addSubview(photosStackView)
+        photosStackView.axis = .horizontal
+        photosStackView.alignment = .fill
+        photosStackView.distribution = .fillEqually
+        photosStackView.spacing = 8.0
+    }
+
     func setRatingImage(_ ratingImage: UIImage) {
         ratingImageView.image = ratingImage
     }
@@ -222,6 +243,8 @@ private final class ReviewCellLayout {
     private(set) var avatarImageFrame = CGRect.zero
     private(set) var userNameLabelFrame = CGRect.zero
     private(set) var ratingImageFrame = CGRect.zero
+    private(set) var photosStackViewFrame = CGRect.zero
+    private(set) var photosScrollViewFrame = CGRect.zero
 
     // MARK: - Отступы
 
@@ -255,6 +278,8 @@ private final class ReviewCellLayout {
         var maxY = insets.top
         var showShowMoreButton = false
 
+        let hasPhotos = config.photos?.isEmpty == false
+
         avatarImageFrame = CGRect (
             origin: CGPoint(x: insets.left, y: insets.top),
             size: Layout.avatarSize
@@ -270,7 +295,27 @@ private final class ReviewCellLayout {
             origin: CGPoint(x: textOriginX, y: maxY),
             size: CGSize(width: 80, height: 16)
         )
-        maxY = ratingImageFrame.maxY + ratingToTextSpacing
+        maxY = ratingImageFrame.maxY + (!hasPhotos ? ratingToTextSpacing : ratingToPhotosSpacing)
+
+        if hasPhotos, let count = config.photos?.count {
+            let photosCount = CGFloat(count)
+            let photosWidth = (Layout.photoSize.width * photosCount) + (photosSpacing * (photosCount - 1))
+            photosScrollViewFrame = CGRect(
+                origin: CGPoint(x: textOriginX, y: maxY),
+                size: CGSize(
+                    width: min(
+                        photosWidth,
+                        maxWidth - insets.right - insets.left - Layout.avatarSize.width - avatarToUsernameSpacing
+                    ),
+                    height: Layout.photoSize.height
+                )
+            )
+            maxY = photosScrollViewFrame.maxY + photosToTextSpacing
+            photosStackViewFrame = CGRect(
+                origin: .zero,
+                size: CGSize(width: photosWidth, height: Layout.photoSize.height)
+            )
+        }
 
         if !config.reviewText.isEmpty() {
             // Высота текста с текущим ограничением по количеству строк.

--- a/Test/Screens/Reviews/Cells/ReviewCell.swift
+++ b/Test/Screens/Reviews/Cells/ReviewCell.swift
@@ -45,6 +45,7 @@ extension ReviewCellConfig: TableCellConfig {
         cell.createdLabel.attributedText = created
         cell.config = self
         cell.setRatingImage(ratingImage)
+        photos.map(cell.addPhotos)
 
         cell.avatarLoadingTask?.cancel()
         cell.avatarLoadingTask = Task {
@@ -135,6 +136,9 @@ final class ReviewCell: UITableViewCell {
         userNameLabel.text = nil
         ratingImageView.image = nil
         config = nil
+        photosStackView.arrangedSubviews.forEach {
+            $0.removeFromSuperview()
+        }
     }
 
 }
@@ -205,6 +209,17 @@ private extension ReviewCell {
         photosStackView.alignment = .fill
         photosStackView.distribution = .fillEqually
         photosStackView.spacing = 8.0
+    }
+
+    func addPhotos(_ photos: [String]) {
+        for photo in photos {
+            let imageView = UIImageView()
+            imageView.contentMode = .scaleAspectFill
+            imageView.clipsToBounds = true
+            imageView.layer.cornerRadius = Layout.photoCornerRadius
+            imageView.image = UIImage(named: photo)
+            photosStackView.addArrangedSubview(imageView)
+        }
     }
 
     func setRatingImage(_ ratingImage: UIImage) {

--- a/Test/Screens/Reviews/Cells/ReviewCell.swift
+++ b/Test/Screens/Reviews/Cells/ReviewCell.swift
@@ -20,6 +20,8 @@ struct ReviewCellConfig {
     let ratingImage: UIImage
     /// Ссылка на аватар пользователя
     let avatarUrl: URL?
+    /// Названия фотографий
+    let photos: [String]?
     /// Замыкание, вызываемое при нажатии на кнопку "Показать полностью...".
     let onTapShowMore: (UUID) -> Void
 

--- a/Test/Screens/Reviews/ReviewsViewModel.swift
+++ b/Test/Screens/Reviews/ReviewsViewModel.swift
@@ -125,6 +125,7 @@ private extension ReviewsViewModel {
             userName: fullName,
             ratingImage: ratingImage,
             avatarUrl: review.avatarUrl,
+            photos: review.photos,
             onTapShowMore: { [weak self] id in
                 self?.showMoreReview(with: id)
             }


### PR DESCRIPTION
# Требования
Добавить в ячейку отзыва фото. Фото в ячейке может быть от 0 от 5. В качестве фото можно использовать изображения, добавленные в Assets проекта, либо сделать асинхронную загрузку изображений

# Описание решения
- добавил свойство `photos` для работы с фотографиями в модель `Review`, json-файл и `ReviewCellConfig`. в качестве фотографий используются изображения из `Assets`
- добавил стек-вью и скролл-вью для отображения фотографий, есть возможность отобразить больше 5 фотографий, но в json добавил максимум 5 в соответствии с требованиями